### PR TITLE
Add README with swagger.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Apply for postgraduate teacher training - API
+
+This is a draft API spec for teacher training applications.
+
+## Getting started
+
+You can [try it out through your browser](https://editor.swagger.io/?url=https://raw.githubusercontent.com/DFE-Digital/apply-for-postgraduate-teacher-training-api/master/api_spec.yml) - nothing will be saved.


### PR DESCRIPTION
Markdown preview:

# Apply for postgraduate teacher training - API

 This is a draft API spec for teacher training applications.

 ## Getting started

 You can [try it out through your browser](https://editor.swagger.io/?url=https://raw.githubusercontent.com/DFE-Digital/apply-for-postgraduate-teacher-training-api/master/api_spec.yml) - nothing will be saved.